### PR TITLE
Workflow improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.ipr
 *.iws
 build
+bin

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.iml
 *.ipr
 *.iws
+build

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ A basic Gradle build file for bootstrapping BRJS Plugin development. Provides a 
 ### Clone the repo and create your project
 - Clone this repository and rename the directory to whatever name you wan't for your project
   - `git clone https://github.com/BladeRunnerJS/brjs-plugin-bootstrap.git MyCoolNewPlugin`
-- Initialise and configure the path to the BladeRunnerJS sdk directory
-  - run `./gradlew init -Pbrjs=<path-to-brjs-sdk-dir>`, this will download the correct version of Gradle, set the brjs path property and create directories where you should place Java source code, resources and test code. It will also create a 'src/main/resources/META-INF/services' directory.
+- Initialise and configure the path to the BladeRunnerJS directory
+  - run `./gradlew init -Pbrjs=<path-to-brjs-dir>`, this will download the correct version of Gradle, set the brjs path property and create directories where you should place Java source code, resources and test code. It will also create a 'src/main/resources/META-INF/services' directory.
 - Delete the 'init' task and configuration from 'build.gradle'. This step is optional, but you won't need the init task again now the directories have been created.
   - In `build.gradle` delete all of the configuration in the `else` block and keep only the configuration in the `if` block.
 - If you are using either Eclipse or InteliJ IDEA set up your project files
   - run `./gradlew eclipse` or `./gradle idea`
-  - For Eclipse the brjs-core source and JavaDocs will also be attached, for InteliJ this must be done manually. The src jar can be found in `<brjs-sdk-dir>/docs/src/`.
+  - For Eclipse the brjs-core source and JavaDocs will also be attached, for InteliJ this must be done manually. The src jar can be found in `<brjs-dir>/docs/src/`.
 - Import the created project in to your IDE of choice.
   - This is generally done by selecting 'Import existing project'.
   - Once the project is imported the relevant dependencies should be added to the classpath for you.

--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ A basic Gradle build file for bootstrapping BRJS Plugin development. Provides a 
 ## Usage
 
 ### Clone the repo and create your project
-- clone this repository and rename the directory to whatever name you wan't for your project
+- Clone this repository and rename the directory to whatever name you wan't for your project
   - `git clone https://github.com/BladeRunnerJS/brjs-plugin-bootstrap.git MyCoolNewPlugin`
-- configure the path to the BladeRunnerJS sdk directory
-  - inside 'build.gradle' change the value of `ext.brjsSdkPath` so the path of your BladeRunnerJS sdk directory. 
-- run `./gradlew init`, this will download the correct version of Gradle and create directories where you should place Java source code, resources and test code. It will also create a 'src/main/resources/META-INF/services' directory.
-- Delete the 'init' task from 'build.gradle'. This step is optional, but you won't need the init task again now the directories have been created.
-  - Delete everything from 'task init, ....' to the closing '}'.
+- Initialise and configure the path to the BladeRunnerJS sdk directory
+  - run `./gradlew init -Pbrjs=<path-to-brjs-sdk-dir>`, this will download the correct version of Gradle, set the brjs path property and create directories where you should place Java source code, resources and test code. It will also create a 'src/main/resources/META-INF/services' directory.
+- Delete the 'init' task and configuration from 'build.gradle'. This step is optional, but you won't need the init task again now the directories have been created.
+  - In `build.gradle` delete all of the configuration in the `else` block and keep only the configuration in the `if` block.
+- If you are using either Eclipse or InteliJ IDEA set up your project files
+  - run `./gradlew eclipse` or `./gradle idea`
+  - For Eclipse the brjs-core source and JavaDocs will also be attached, for InteliJ this must be done manually. The src jar can be found in `<brjs-sdk-dir>/docs/src/`.
 - Import the created project in to your IDE of choice.
   - This is generally done by selecting 'Import existing project'.
   - Once the project is imported the relevant dependencies should be added to the classpath for you.
@@ -34,6 +36,7 @@ A basic Gradle build file for bootstrapping BRJS Plugin development. Provides a 
 ### Build the plugin
 - Run `./gradlew build` to build and test your plugin.
 - Once the build has passed, your plugin is built and placed in the 'build/libs/' directory.
+- You can run `./gradlew copyToBrjs` to automatically copy your jar to the conf/java directory to be picked up by BRJS.
 
 ## More reading
 - [BRJS getting started guide](http://bladerunnerjs.org/docs/use/getting_started/)

--- a/build.gradle
+++ b/build.gradle
@@ -3,36 +3,56 @@ apply plugin: 'idea'
 apply plugin: 'java'
 
 // Note: brjsSdkPath is set in gradle.properties
-dependencies {
-	if (project.hasProperty("brjsSdkPath"))		compile fileTree(dir:ext.brjsSdkPath, include:"libs/java/system/*.jar")
-}
-
-/* this init task can be deleted once the project has been initialised */
-task init, dependsOn: [tasks.eclipse, tasks.idea], {
-	description "Creates Gradle properties file, directories for src and resources along with the META-INF/services for plugin definitions"
-	doFirst {
-		def brjsPropName = "brjs"
-		if (!project.hasProperty(brjsPropName))
-		{
-			throw new GradleException("Please supply the path to your BRJS sdk directory.\nFor example if your BRJS sdk dir is '/home/bob/brjs/1.0/sdk' run './gradlew init -P${brjsPropName}=/home/bob/brjs/1.0/sdk'.")
-		}
-		def brjsPropValue = project.property(brjsPropName)
-		def brjsDirPath = new File(brjsPropValue)
-		if (!brjsDirPath.isDirectory())
-		{
-			throw new GradleException("The BRJS path supplied, '${brjsPropValue}', resolves to the path '${brjsDirPath.getCanonicalPath()}' which either doesn't exist or is not a directory. Please ensure it is a valid path to the BRJS sdk dir.")
-		}
-		def gradlePropsFile = file("gradle.properties")
-		if (gradlePropsFile.exists())
-		{
-			throw new GradleException("${gradlePropsFile.path} exists, meaning this project has probably already been initialised and can't be initialised again.")
-		}
-		gradlePropsFile.write("brjsSdkPath=${brjsDirPath.getCanonicalPath()}");
-		[file("src/main/java"), file("src/main/resources/META-INF/services"), file("src/test/java"), file("src/test/resources")].each {
-			if (!it.exists()) { it.mkdirs() }
-		}
-		println "\n"+
-			"src and resources directories created successfully, you can now delete the '${tasks.init.name}' task from build.gradle.\n"+
-			"Run './gradlew tasks' to view a list of tasks available via Gradle or read README.md for more info.\n"
+if (project.hasProperty("brjsSdkPath")) 
+{
+	dependencies {
+		compile fileTree(dir:ext.brjsSdkPath, include:"libs/java/system/*.jar")
 	}
+
+	task copyToBrjs, type: Copy, dependsOn: jar, {
+		def brjsConfJavaDir = new File(brjsSdkPath, "../conf/java")
+		from jar.outputs.files.singleFile
+		into brjsConfJavaDir
+		doLast {
+			println "${project.name} jar copied to ${brjsConfJavaDir.getAbsolutePath()}"
+		}
+	}
+}
+else
+{
+	/* 
+	 *  This configuration, and the wrapping if/else statement can be deleted once the project has been initialised.
+	 *  Make sure to keep the dependencies configuration and other tasks.
+	 */
+	println("\n## WARNING: You are attempting to run a command(s) before initialising this project. You should first run the 'init' task. ##\n")
+
+	task init, dependsOn: [tasks.eclipse, tasks.idea], {
+		description "Creates Gradle properties file, directories for src and resources along with the META-INF/services for plugin definitions"
+		doFirst {
+			def brjsPropName = "brjs"
+			if (!project.hasProperty(brjsPropName))
+			{
+				throw new GradleException("Please supply the path to your BRJS sdk directory.\nFor example if your BRJS sdk dir is '/home/bob/brjs/1.0/sdk' run './gradlew init -P${brjsPropName}=/home/bob/brjs/1.0/sdk'.")
+			}
+			def brjsPropValue = project.property(brjsPropName)
+			def brjsDirPath = new File(brjsPropValue)
+			if (!brjsDirPath.isDirectory())
+			{
+				throw new GradleException("The BRJS path supplied, '${brjsPropValue}', resolves to the path '${brjsDirPath.getCanonicalPath()}' which either doesn't exist or is not a directory. Please ensure it is a valid path to the BRJS sdk dir.")
+			}
+			def gradlePropsFile = file("gradle.properties")
+			if (gradlePropsFile.exists())
+			{
+				throw new GradleException("${gradlePropsFile.path} exists, meaning this project has probably already been initialised and can't be initialised again.")
+			}
+			gradlePropsFile.write("brjsSdkPath=${brjsDirPath.getCanonicalPath()}");
+			[file("src/main/java"), file("src/main/resources/META-INF/services"), file("src/test/java"), file("src/test/resources")].each {
+				if (!it.exists()) { it.mkdirs() }
+			}
+			println "\n"+
+				"src and resources directories created successfully, you can now delete the 'init' task from build.gradle.\n"+
+				"Run './gradlew tasks' to view a list of tasks available via Gradle or read README.md for more info.\n"
+		}
+	}
+
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,16 @@
-// Note: brjsSdkPath is set in gradle.properties
-if (project.hasProperty("brjsSdkPath")) 
+// Note: brjsPath is set in gradle.properties
+if (project.hasProperty("brjsPath")) 
 {
 	apply plugin: 'eclipse'
 	apply plugin: 'idea'
 	apply plugin: 'java'
 
 	dependencies {
-		compile fileTree(dir:ext.brjsSdkPath, include:"libs/java/system/*.jar")
+		compile fileTree(dir:brjsPath, include:"sdk/libs/java/system/*.jar")
 	}
 
 	task copyToBrjs, type: Copy, dependsOn: jar, {
-		def brjsConfJavaDir = new File("${brjsSdkPath}/../conf/java")
+		def brjsConfJavaDir = new File("${brjsPath}/conf/java")
 		from jar.outputs.files.singleFile
 		into brjsConfJavaDir
 		doLast {
@@ -22,8 +22,8 @@ if (project.hasProperty("brjsSdkPath"))
 	tasks.eclipse.doLast {
 		try {
 			def classPathFile = file(".classpath")
-			String brjsCoreJar = fileTree(dir:brjsSdkPath, include:"libs/java/system/brjs-core-*.jar").singleFile
-			String brjsSrcJar = fileTree(dir:brjsSdkPath, include:"docs/src/*.jar").singleFile
+			String brjsCoreJar = fileTree(dir:brjsPath, include:"sdk/libs/java/system/brjs-core-*.jar").singleFile
+			String brjsSrcJar = fileTree(dir:brjsPath, include:"sdk/docs/src/*.jar").singleFile
 			def findString = "path=\"${brjsCoreJar}\""
 			def replaceString = findString + " sourcepath=\"${brjsSrcJar}\""
 			if (classPathFile.exists()) {
@@ -49,20 +49,25 @@ else
 			def brjsPropName = "brjs"
 			if (!project.hasProperty(brjsPropName))
 			{
-				throw new GradleException("Please supply the path to your BRJS sdk directory.\nFor example if your BRJS sdk dir is '/home/bob/brjs/1.0/sdk' run './gradlew init -P${brjsPropName}=/home/bob/brjs/1.0/sdk'.")
+				throw new GradleException("Please supply the path to your BRJS directory.\nFor example if your BRJS dir is '/home/bob/brjs/1.0' run './gradlew init -P${brjsPropName}=/home/bob/brjs/1.0'.")
 			}
 			def brjsPropValue = project.property(brjsPropName)
-			def brjsDirPath = new File(brjsPropValue)
-			if (!brjsDirPath.isDirectory())
+			def brjsDir = new File(brjsPropValue)
+			if (!brjsDir.isDirectory())
 			{
-				throw new GradleException("The BRJS path supplied, '${brjsPropValue}', resolves to the path '${brjsDirPath.getCanonicalPath()}' which either doesn't exist or is not a directory. Please ensure it is a valid path to the BRJS sdk dir.")
+				throw new GradleException("The BRJS path supplied, '${brjsPropValue}', resolves to the path '${brjsDir.getCanonicalPath()}' which either doesn't exist or is not a directory. Please ensure it is a valid path to the BRJS sdk dir.")
+			}
+			def brjsSdkDir = new File(brjsDir, "sdk")
+			if (!brjsSdkDir.isDirectory())
+			{
+				throw new GradleException("The BRJS path, '${brjsDir.getCanonicalPath()}', doesnt appear to be a valid BRJS directory since it doesn't contain an 'sdk' directory.")
 			}
 			def gradlePropsFile = file("gradle.properties")
 			if (gradlePropsFile.exists())
 			{
 				throw new GradleException("${gradlePropsFile.path} exists, meaning this project has probably already been initialised and can't be initialised again.")
 			}
-			gradlePropsFile.write("brjsSdkPath=${brjsDirPath.getCanonicalPath()}");
+			gradlePropsFile.write("brjsPath=${brjsDir.getCanonicalPath()}");
 			[file("src/main/java"), file("src/main/resources/META-INF/services"), file("src/test/java"), file("src/test/resources")].each {
 				if (!it.exists()) { it.mkdirs() }
 			}

--- a/build.gradle
+++ b/build.gradle
@@ -10,13 +10,26 @@ if (project.hasProperty("brjsSdkPath"))
 	}
 
 	task copyToBrjs, type: Copy, dependsOn: jar, {
-		def brjsConfJavaDir = new File(brjsSdkPath, "../conf/java")
+		def brjsConfJavaDir = new File("${brjsSdkPath}/../conf/java")
 		from jar.outputs.files.singleFile
 		into brjsConfJavaDir
 		doLast {
 			println "${project.name} jar copied to ${brjsConfJavaDir.getAbsolutePath()}"
 		}
 	}
+
+	// automatically add brjs-core sources jar for Eclipse classpath
+	tasks.eclipse.doLast {
+		def classPathFile = file(".classpath")
+		String brjsCoreJar = fileTree(dir:brjsSdkPath, include:"libs/java/system/brjs-core-*.jar").singleFile
+		String brjsSrcJar = fileTree(dir:brjsSdkPath, include:"docs/src/*.jar").singleFile
+		def findString = "path=\"${brjsCoreJar}\""
+		def replaceString = findString + " sourcepath=\"${brjsSrcJar}\""
+		if (classPathFile.exists()) {
+			classPathFile.write( classPathFile.text.replace(findString, replaceString) )
+		}
+	}
+
 }
 else
 {
@@ -51,7 +64,7 @@ else
 			}
 			println "\n"+
 				"gradle.properties and src & resources directories created successfully, you can now delete the 'init' task from build.gradle.\n"+
-				"You should now run './gradlew eclipse' or './gradlew idea' to generate the project files for your IDE.\n"+
+				"You should now run './gradlew eclipse' or './gradlew idea' to generate the project files for your IDE and can then run tasks to compile and test your project.\n"+
 				"Run './gradlew tasks' to view a list of tasks available via Gradle or read README.md for more info.\n"
 		}
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -2,21 +2,31 @@ apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'java'
 
-ext.brjsSdkPath = "<path/to/your/BRJS/sdk/dir - e.g. /home/bob/brjs/1.0/sdk>"
-
+// Note: brjsSdkPath is set in gradle.properties
 dependencies {
-	compile fileTree(dir:ext.brjsSdkPath, include:"libs/java/system/*.jar")
+	if (project.hasProperty("brjsSdkPath"))		compile fileTree(dir:ext.brjsSdkPath, include:"libs/java/system/*.jar")
 }
 
 task init, dependsOn: [tasks.eclipse, tasks.idea], {
-	description "Creates directories for src and resources along with the META-INF/services for plugin definitions"
-	if (project.ext.brjsSdkPath.startsWith("<")) { throw new GradleException("You need to set 'brjsSdkPath' at the top of build.gradle before trying to run any tasks.")}
+	description "Creates Gradle properties file, directories for src and resources along with the META-INF/services for plugin definitions"
 	doFirst {
+		def brjsPropName = "brjs"
+		if (!project.hasProperty(brjsPropName))
+		{
+			throw new GradleException("Please supply the path to your BRJS sdk directory.\nFor example if your BRJS sdk dir is '/home/bob/brjs/1.0/sdk' run './gradlew init -P${brjsPropName}=/home/bob/brjs/1.0/sdk'.")
+		}
+		def brjsPropValue = project.property(brjsPropName)
+		def gradlePropsFile = file("gradle.properties")
+		if (gradlePropsFile.exists())
+		{
+			throw new GradleException("${gradlePropsFile.path} exists, meaning this project has probably already been initialised and can't be initialised again.")
+		}
+		gradlePropsFile.write("brjsSdkPath=${brjsPropValue}");
 		[file("src/main/java"), file("src/main/resources/META-INF/services"), file("src/test/java"), file("src/test/resources")].each {
 			if (!it.exists()) { it.mkdirs() }
 		}
 		println "\n"+
-	"src and resources directories created successfully, you can now delete the '${tasks.init.name}' task from build.gradle.\n"+
-	"Run './gradlew tasks' to view a list of tasks available via Gradle or read README.md for more info.\n"
+			"src and resources directories created successfully, you can now delete the '${tasks.init.name}' task from build.gradle.\n"+
+			"Run './gradlew tasks' to view a list of tasks available via Gradle or read README.md for more info.\n"
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	if (project.hasProperty("brjsSdkPath"))		compile fileTree(dir:ext.brjsSdkPath, include:"libs/java/system/*.jar")
 }
 
+/* this init task can be deleted once the project has been initialised */
 task init, dependsOn: [tasks.eclipse, tasks.idea], {
 	description "Creates Gradle properties file, directories for src and resources along with the META-INF/services for plugin definitions"
 	doFirst {
@@ -16,12 +17,17 @@ task init, dependsOn: [tasks.eclipse, tasks.idea], {
 			throw new GradleException("Please supply the path to your BRJS sdk directory.\nFor example if your BRJS sdk dir is '/home/bob/brjs/1.0/sdk' run './gradlew init -P${brjsPropName}=/home/bob/brjs/1.0/sdk'.")
 		}
 		def brjsPropValue = project.property(brjsPropName)
+		def brjsDirPath = new File(brjsPropValue)
+		if (!brjsDirPath.isDirectory())
+		{
+			throw new GradleException("The BRJS path supplied, '${brjsPropValue}', resolves to the path '${brjsDirPath.getCanonicalPath()}' which either doesn't exist or is not a directory. Please ensure it is a valid path to the BRJS sdk dir.")
+		}
 		def gradlePropsFile = file("gradle.properties")
 		if (gradlePropsFile.exists())
 		{
 			throw new GradleException("${gradlePropsFile.path} exists, meaning this project has probably already been initialised and can't be initialised again.")
 		}
-		gradlePropsFile.write("brjsSdkPath=${brjsPropValue}");
+		gradlePropsFile.write("brjsSdkPath=${brjsDirPath.getCanonicalPath()}");
 		[file("src/main/java"), file("src/main/resources/META-INF/services"), file("src/test/java"), file("src/test/resources")].each {
 			if (!it.exists()) { it.mkdirs() }
 		}

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
-apply plugin: 'eclipse'
-apply plugin: 'idea'
-apply plugin: 'java'
-
 // Note: brjsSdkPath is set in gradle.properties
 if (project.hasProperty("brjsSdkPath")) 
 {
+	apply plugin: 'eclipse'
+	apply plugin: 'idea'
+	apply plugin: 'java'
+
 	dependencies {
 		compile fileTree(dir:ext.brjsSdkPath, include:"libs/java/system/*.jar")
 	}
@@ -26,7 +26,7 @@ else
 	 */
 	println("\n## WARNING: You are attempting to run a command(s) before initialising this project. You should first run the 'init' task. ##\n")
 
-	task init, dependsOn: [tasks.eclipse, tasks.idea], {
+	task init, {
 		description "Creates Gradle properties file, directories for src and resources along with the META-INF/services for plugin definitions"
 		doFirst {
 			def brjsPropName = "brjs"
@@ -50,7 +50,8 @@ else
 				if (!it.exists()) { it.mkdirs() }
 			}
 			println "\n"+
-				"src and resources directories created successfully, you can now delete the 'init' task from build.gradle.\n"+
+				"gradle.properties and src & resources directories created successfully, you can now delete the 'init' task from build.gradle.\n"+
+				"You should now run './gradlew eclipse' or './gradlew idea' to generate the project files for your IDE.\n"+
 				"Run './gradlew tasks' to view a list of tasks available via Gradle or read README.md for more info.\n"
 		}
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -20,13 +20,17 @@ if (project.hasProperty("brjsSdkPath"))
 
 	// automatically add brjs-core sources jar for Eclipse classpath
 	tasks.eclipse.doLast {
-		def classPathFile = file(".classpath")
-		String brjsCoreJar = fileTree(dir:brjsSdkPath, include:"libs/java/system/brjs-core-*.jar").singleFile
-		String brjsSrcJar = fileTree(dir:brjsSdkPath, include:"docs/src/*.jar").singleFile
-		def findString = "path=\"${brjsCoreJar}\""
-		def replaceString = findString + " sourcepath=\"${brjsSrcJar}\""
-		if (classPathFile.exists()) {
-			classPathFile.write( classPathFile.text.replace(findString, replaceString) )
+		try {
+			def classPathFile = file(".classpath")
+			String brjsCoreJar = fileTree(dir:brjsSdkPath, include:"libs/java/system/brjs-core-*.jar").singleFile
+			String brjsSrcJar = fileTree(dir:brjsSdkPath, include:"docs/src/*.jar").singleFile
+			def findString = "path=\"${brjsCoreJar}\""
+			def replaceString = findString + " sourcepath=\"${brjsSrcJar}\""
+			if (classPathFile.exists()) {
+				classPathFile.write( classPathFile.text.replace(findString, replaceString) )
+			}
+		} catch (IllegalStateException ex) {  // we do nothing with the exception, it was probably thrown because the src jar doesnt exist
+			println "Warning: Exception was thrown when attempting to add the brjs-core src jar to the classpath. This was probably because the src jar doesn't exist.\nThe exception was: \n>> ${ex.toString()}"
 		}
 	}
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,15 +22,16 @@ if (project.hasProperty("brjsPath"))
 	tasks.eclipse.doLast {
 		try {
 			def classPathFile = file(".classpath")
-			String brjsCoreJar = fileTree(dir:brjsPath, include:"sdk/libs/java/system/brjs-core-*.jar").singleFile
-			String brjsSrcJar = fileTree(dir:brjsPath, include:"sdk/docs/src/*.jar").singleFile
+			String brjsCoreJar = fileTree(dir:"${brjsPath}/sdk/libs/java/system", include:"brjs-core-*.jar").singleFile
+			String brjsSrcJar = fileTree(dir:"${brjsPath}/sdk/docs/src", include:"brjs-core-*-sources.jar").singleFile
 			def findString = "path=\"${brjsCoreJar}\""
 			def replaceString = findString + " sourcepath=\"${brjsSrcJar}\""
 			if (classPathFile.exists()) {
 				classPathFile.write( classPathFile.text.replace(findString, replaceString) )
 			}
-		} catch (IllegalStateException ex) {  // we do nothing with the exception, it was probably thrown because the src jar doesnt exist
-			println "Warning: Exception was thrown when attempting to add the brjs-core src jar to the classpath. This was probably because the src jar doesn't exist.\nThe exception was: \n>> ${ex.toString()}"
+		} catch (IllegalStateException ex) {  // do nothing with the exception, it was probably thrown because the src jar doesnt exist
+			logger.warn("Warning: Exception was thrown when attempting to add the brjs-core src jar to the classpath. Sources will not be added to the Eclipse classpath.")
+			logger.debug(ex.toString())
 		}
 	}
 
@@ -41,7 +42,7 @@ else
 	 *  This configuration, and the wrapping if/else statement can be deleted once the project has been initialised.
 	 *  Make sure to keep the dependencies configuration and other tasks.
 	 */
-	println("\n## WARNING: You are attempting to run a command(s) before initialising this project. You should first run the 'init' task. ##\n")
+	logger.warn("\n## WARNING: You are attempting to run a command(s) before initialising this project. You should first run the 'init' task. ##\n")
 
 	task init, {
 		description "Creates Gradle properties file, directories for src and resources along with the META-INF/services for plugin definitions"

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ else
 	 *  This configuration, and the wrapping if/else statement can be deleted once the project has been initialised.
 	 *  Make sure to keep the dependencies configuration and other tasks.
 	 */
-	logger.warn("\n## WARNING: You are attempting to run a command(s) before initialising this project. You should first run the 'init' task. ##\n")
+	logger.warn("\n## WARNING: You are attempting to run a command(s) before initialising this project. You should first run the 'init' task. (If you are running the init task you can ignore this message) ##\n")
 
 	task init, {
 		description "Creates Gradle properties file, directories for src and resources along with the META-INF/services for plugin definitions"


### PR DESCRIPTION
@leggetter can you take a look at this and let me know if there are any extra improvements that need to be made before Tuesday?
- BRJS path is now taken as a property for the init task
  - e.g. `./gradlew init -Pbrjs=/some/path/to/sdk`
- now checks that the path supplied for BRJS is valid
- new task (`copyToBrjs`) to copy the jar in to brjs conf/java dir
- correctly generates the eclipse/idea classpath, unfortunately this has to be done as a separate run of gradle. So the workflow is now `gradle init` followed by `gradle eclipse`
- now adds the src jar to the classpath (for Eclipse only)
