### PR TITLE
The copyToBrjs gradle task now copies to the apps/*/WEB-INF/lib directories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,13 +9,33 @@ if (project.hasProperty("brjsPath"))
 		compile fileTree(dir:brjsPath, include:"sdk/libs/java/system/*.jar")
 	}
 
-	task copyToBrjs, type: Copy, dependsOn: jar, {
+	task copyToConf, type: Copy, dependsOn: jar, {
 		def brjsConfJavaDir = new File("${brjsPath}/conf/java")
 		from jar.outputs.files.singleFile
 		into brjsConfJavaDir
 		doLast {
 			println "${project.name} jar copied to ${brjsConfJavaDir.getAbsolutePath()}"
 		}
+	}
+
+	task copyToApps, type: Copy, dependsOn: jar, {
+		destinationDir file("${brjsPath}/apps")
+		file("${brjsPath}/apps").listFiles().each {
+			if (it.isDirectory()) {
+				into ("${it.name}/WEB-INF/lib") {
+					from jar.outputs.files.singleFile
+				}
+			}
+		}
+		doFirst {
+			fileTree(dir:"${brjsPath}/apps", include:"*/WEB-INF/lib/${project.name}.jar").each { delete it }
+		}
+		doLast {
+			println "${project.name} jar copied to ${brjsPath}/apps/*/WEB-INF/lib"
+		}
+	}
+
+	task copyToBrjs, dependsOn: [copyToConf, copyToApps], {
 	}
 
 	// automatically add brjs-core sources jar for Eclipse classpath


### PR DESCRIPTION
fixes BladeRunnerJS/brjs-plugin-bootstrap#2

I ended up doing this to make my life easier when working on the appcache plugin, so it might be worth pulling back until BladeRunnerJS/brjs#91 is sorted.
